### PR TITLE
added second meta var for engines....

### DIFF
--- a/lib/Engine_Wobble.sc
+++ b/lib/Engine_Wobble.sc
@@ -17,7 +17,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator1",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=0,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // 1) constant value
             mod = maxval;
@@ -38,7 +38,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator2",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=0,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // sine
             mod=SinOsc.kr(hz).range(minval,maxval);
@@ -59,7 +59,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator3",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=1,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // triangle
             mod=LFTri.kr(hz).range(minval,maxval);
@@ -80,10 +80,10 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator4",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=1,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // wobbly sine
-            mod=SinOsc.kr(VarLag.kr(LFNoise0.kr(hz*(2+meta)).range(0,hz*(2+meta)),1/(hz*(2+meta)),warp:\sine)).range(minval,maxval);
+            mod=SinOsc.kr(VarLag.kr(LFNoise0.kr(hz*(2+meta)).range(0,hz*(2+meta)),1/(hz*(2+meta2)),warp:\sine)).range(minval,maxval);
             env = EnvGen.kr(
                 Env.new(
                     levels: [0,level,sustain*level,0],
@@ -101,7 +101,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator5",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=1,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // snek
             mod=VarLag.kr(LFNoise0.kr(hz).range(minval,maxval),1/(hz),warp:\sine);
@@ -122,14 +122,14 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator6",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=1,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // lorenz
             mod=LorenzL.ar(
                     hz*10,
-                    LFNoise0.kr(hz*10/20, 2, 10),
-                    LFNoise0.kr(hz*10/20, 20, 38),
-                    LFNoise0.kr(hz*10/20, 1.5, 2)
+                    LFNoise0.kr(hz*10/20, 2+meta, 10+meta2),
+                    LFNoise0.kr(hz*10/20, 20+meta, 38+meta2),
+                    LFNoise0.kr(hz*10/20, 1.5+meta, 2+meta2)
                 ).range(minval,maxval);
             env = EnvGen.kr(
                 Env.new(
@@ -148,7 +148,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator7",{
             arg hz=1,minval=0,maxval=1,index=1,
             midigate=0,midival=0,addenv=0,addmidi=1,
-            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+            level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // henon
             mod=Clip.kr(HenonC.ar(hz,LFNoise0.kr(17).range(1,2),LFNoise0.kr(11).range(0.2,0.4)).range(minval*1.02,maxval*0.98),minval,maxval);
@@ -169,7 +169,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator8",{
     arg hz=1,minval=0,maxval=1,index=1,
     midigate=0,midival=0,addenv=0,addmidi=1,
-    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // random walk
             mod=VarLag.kr(LFBrownNoise0.kr(hz),1/hz,warp:\sine).range(minval,maxval);
@@ -191,7 +191,7 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator9",{
     arg hz=1,minval=0,maxval=1,index=1,
     midigate=0,midival=0,addenv=0,addmidi=1,
-    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             
             // latoocarfian 
@@ -214,10 +214,10 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator10",{
     arg hz=1,minval=0,maxval=1,index=1,
     midigate=0,midival=0,addenv=0,addmidi=1,
-    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0;
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             // feedback sine 
-            mod=Clip.kr(FBSineC.ar( hz*10, 1, meta, LFNoise2.kr(hz*10/20, 0.05, 1.05), LFNoise2.kr(hz*10/20, 0.3, 0.3)).range(minval*1.02,maxval*0.98),minval,maxval);
+            mod=FBSineC.ar( hz*10, 1, meta, LFNoise2.kr(hz*10/20, 0.05, 1.05+meta2), LFNoise2.kr(hz*10/20, 0.3, 0.3+meta2)).range(minval*1.02,maxval*0.98);
             //mod=VarLag.kr(LFBrownNoise0.kr(hz),1/hz,warp:\sine).range(minval,maxval);
             env = EnvGen.kr(
                 Env.new(
@@ -236,12 +236,12 @@ Engine_Wobble : CroneEngine {
         SynthDef("modulator11",{
     arg hz=1,minval=0,maxval=1,index=1,
     midigate=0,midival=0,addenv=0,addmidi=1,
-    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,
-    meta=0;
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
             var mod,env;
             var a = 3.5441;
-            // feedback sine 
-            mod=Clip.kr(QuadC.ar( hz*10, meta.neg + a.neg, meta + a, 0, 0.1).range(minval*1.02,maxval*0.98),minval,maxval);
+
+            mod=QuadC.ar( hz*10, meta.neg + a.neg, meta + a, meta2, 0.1).range(minval*1.02,maxval*0.98);
+
             //mod=VarLag.kr(LFBrownNoise0.kr(hz),1/hz,warp:\sine).range(minval,maxval);
             env = EnvGen.kr(
                 Env.new(
@@ -257,7 +257,49 @@ Engine_Wobble : CroneEngine {
             SendTrig.kr(Impulse.kr(15),index,mod);      
         }).add;
 
+        SynthDef("modulator12",{
+    arg hz=1,minval=0,maxval=1,index=1,
+    midigate=0,midival=0,addenv=0,addmidi=1,
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
+            var mod,env;
+            // standard map chaotic generator
+            mod=StandardL.ar( hz*10, meta).range(minval*1.02,maxval*0.98);
+            //mod=VarLag.kr(LFBrownNoise0.kr(hz),1/hz,warp:\sine).range(minval,maxval);
+            env = EnvGen.kr(
+                Env.new(
+                    levels: [0,level,sustain*level,0],
+                    times: [attack,decay,release],
+                    curve:\cubed,
+                    releaseNode: 2,
+                ),
+                gate: midigate,
+            );
+            mod = mod + (addenv*env);
+            mod = mod + (addmidi*((midival-48)/12));
+            SendTrig.kr(Impulse.kr(15),index,mod);      
+        }).add;
 
+        SynthDef("modulator13",{
+    arg hz=1,minval=0,maxval=1,index=1,
+    midigate=0,midival=0,addenv=0,addmidi=1,
+    level=5,attack=0.2,sustain=0.9,decay=0.1,release=0.5,meta=0,meta2=0;
+            var mod,env;
+            // gingerbread man
+            mod=GbmanL.ar( hz, -1.3+meta, -2.7+meta2).range(minval*1.02,maxval*0.98) * 0.4;
+            //mod=VarLag.kr(LFBrownNoise0.kr(hz),1/hz,warp:\sine).range(minval,maxval);
+            env = EnvGen.kr(
+                Env.new(
+                    levels: [0,level,sustain*level,0],
+                    times: [attack,decay,release],
+                    curve:\cubed,
+                    releaseNode: 2,
+                ),
+                gate: midigate,
+            );
+            mod = mod + (addenv*env);
+            mod = mod + (addmidi*((midival-48)/12));
+            SendTrig.kr(Impulse.kr(15),index,mod);      
+        }).add;
         context.server.sync;
 
         osfunWobble = OSCFunc({ 
@@ -355,6 +397,11 @@ Engine_Wobble : CroneEngine {
         this.addCommand("meta","if", { arg msg;
             modulatorsWobble[msg[1]-1].set(
                 \meta,msg[2],
+            );
+        });
+        this.addCommand("meta2","if", { arg msg;
+            modulatorsWobble[msg[1]-1].set(
+                \meta2,msg[2],
             );
         });
         // ^ Wobble specific

--- a/lib/wobblewobble.lua
+++ b/lib/wobblewobble.lua
@@ -277,13 +277,22 @@ function Wobble:init()
   end
 
   crow.input[1].mode("stream")
-  crow.input[1].stream = function(v) 
+  crow.input[1].stream = function(v)
       self.input1 = v
-  end
 
+      do_update=false
+      curfreq = params:get("1freq")
+      engine.hz(1,v+curfreq)
+      do_update=true
+  end
   crow.input[2].mode("stream")
-  crow.input[2].stream = function(v) 
+  crow.input[2].stream = function(v)
       self.input2 = v
+
+      do_update=false
+      curfreq = params:get("2freq")
+      engine.hz(2,v+curfreq)
+      do_update=true
   end
 
   -- setup osc
@@ -307,14 +316,6 @@ function Wobble:init()
      end
    end
   end
-end
-
-function Wobble:crowinput1(v)
-    self.volts1 = v
-end
-
-function Wobble:crowinput1(v)
-    self.volts2 = v
 end
 
 function Wobble:setmidi(i)

--- a/lib/wobblewobble.lua
+++ b/lib/wobblewobble.lua
@@ -19,6 +19,11 @@ end
 function Wobble:grid_key(x,y,z)
     local currentout=params:get("crow")
 
+    if x == 1 and y == 1 and z == 1 then
+        self.tog = 1 - self.tog
+        self.g:led(1, 1, 15 * self.tog)
+    end
+
     if y > 1 and y < 6 then
         local crowmodkey = (y - 1).."modulation"
         local currentmod = params:get(crowmodkey)
@@ -66,14 +71,15 @@ end
 
 function Wobble:init()
   -- menu stuff
-  self.param_names={"minval","maxval","freq","period","modulation","midiin","miditype","clampmin","clampmax","meta"}
+  self.param_names={"minval","maxval","freq","period","modulation","midiin","miditype","clampmin","clampmax","meta","meta2"}
   self.midi_names={"level","attack","decay","sustain","release"}
   self.midi_types={"envelope","any note","top note"}
   -- setup modulations
-  self.modulations={"constant","sine","triangle","wobbly sine","snek","lorenz","henon","random walk","latoocarfian", "fbsine", "quad"}
+  self.modulations={"constant","sine","triangle","wobbly sine","snek","lorenz","henon","random walk","latoocarfian", "fbsine", "quad", "standardmap", "cookie"}
   self.outputs={"none"}
   self.input1=0
   self.input2=0
+  self.tog=0
 
   -- initiate the grid
   self.g=grid.connect()
@@ -173,7 +179,8 @@ function Wobble:init()
         params:get(i.."decay"),
         params:get(i.."sustain"),
         params:get(i.."release"),
-        params:get(i.."meta")
+        params:get(i.."meta"),
+        params:get(i.."meta2")
       )
       self:setmidi(i)
     end
@@ -200,7 +207,17 @@ function Wobble:init()
     end
     }
 
-    params:add{type="control",id=i.."meta",name="meta",controlspec=controlspec.new(0,300,'lin',0,0,'metas',0.01/300),action=function(v)
+    params:add{type="control",id=i.."meta",name="meta",controlspec=controlspec.new(-300,300,'lin',0,0,'metas',0.01/300),action=function(v)
+      if not do_update then 
+        do return end 
+      end
+      do_update=false
+      engine.meta(i,v)
+      do_update=true
+    end
+    }
+
+    params:add{type="control",id=i.."meta2",name="meta2",controlspec=controlspec.new(-300,300,'lin',0,0,'metas',0.01/300),action=function(v)
       if not do_update then 
         do return end 
       end
@@ -329,6 +346,7 @@ function Wobble:get()
     min=params:get(i.."minval"),
     max=params:get(i.."maxval"),
     meta=params:get(i.."meta"),
+    meta2=params:get(i.."meta2"),
     midi=midiname,
     miditype=self.midi_types[params:get(i.."miditype")],
   }

--- a/wobblewobble.lua
+++ b/wobblewobble.lua
@@ -42,16 +42,32 @@ function key(k,z)
 end
 
 function enc(k,d)
+    print(k)
 	if k==1 then
 		params:delta(params:get("crow").."freq",d)
-	elseif k==2 then 
-		params:delta(params:get("crow").."minval",d)
-	elseif k==3 then
-		params:delta(params:get("crow").."maxval",d)
 	else
         -- fates specific, enc 4
-		params:delta(params:get("crow").."meta",d)
+        if k==4 then
+            if ww.tog == 0 then
+                params:delta(params:get("crow").."meta",d)
+            else
+                params:delta(params:get("crow").."meta2",d)
+            end
+        end
 	end
+    if ww.tog == 0 then
+        if k==2 then 
+            params:delta(params:get("crow").."minval",d)
+        elseif k==3 then
+            params:delta(params:get("crow").."maxval",d)
+        end
+    else
+        if k==2 then 
+            params:delta(params:get("crow").."meta",d)
+        elseif k==3 then
+            params:delta(params:get("crow").."meta2",d)
+        end
+    end
 end
 
 function redraw()
@@ -74,18 +90,58 @@ function redraw()
 	screen.text(s)
 	screen.stroke()
 
-	screen.level(8)
-    s = string.format("%.2fhz,%.2f-%.2fv %.2f %.1f/%.1f", cur.freq, cur.min, cur.max, cur.meta, ww.input1, ww.input2)
+    s = string.format("%.2fhz,%.2f - %.2fv", cur.freq, cur.min, cur.max)
+
+    -- ww.input1, ww.input2
 
 	if cur.name=="constant" then
 		s=string.format("%.2fhz %.2fv", cur.freq, cur.max)
 	end
 
+    if ww.tog == 0 then
+        fg = 0
+        bg = 8
+    else
+        fg = 8
+        bg = 0
+    end
+
+	screen.level(bg)
 	screen.rect(2,64-7,screen.text_extents(s)+4,10)
 	screen.fill()
-	screen.level(0)
+	screen.level(fg)
 	screen.move(4,64-1)
 	screen.text(s)
+	screen.stroke()
+
+    sm = string.format("%.2f %.2f", cur.meta, cur.meta2)
+
+    if ww.tog == 1 then
+        fg = 0
+        bg = 8
+    else
+        fg = 8
+        bg = 0
+    end
+
+	screen.level(bg)
+	screen.rect(128-screen.text_extents(sm)-3,64-7,128-screen.text_extents(sm)+4,10)
+	screen.fill()
+	screen.level(fg)
+	screen.move(128-screen.text_extents(sm)-1,64-1)
+	screen.text(sm)
+	screen.stroke()
+
+	screen.level(1)
+    si = string.format("%.2f", ww.input2)
+	screen.move(128-screen.text_extents(si)-1,8)
+	screen.text(si)
+	screen.stroke()
+
+	screen.level(1)
+    si = string.format("%.2f", ww.input1)
+	screen.move(128-screen.text_extents(si)-22,8)
+	screen.text(si)
 	screen.stroke()
 
 	screen.level(8)


### PR DESCRIPTION
grid 1,1 now toggles editing meta1 + meta2 with e2 and e3 [i need to think of how to change this so grid isn't required]
input levels on main screen and other drawing changes (for toggle)
added standardmap and gingerbreadman (cookie) attractors
added support for meta / meta2 in engines where that is useful (still pretty haphazard, but that seems to be how these are)